### PR TITLE
[RFC][UN-14538] Fix unexpected stack trace of error

### DIFF
--- a/internal/logrus.go
+++ b/internal/logrus.go
@@ -177,11 +177,11 @@ func firstStackTracerInErrorChain(err error) error {
 		}
 
 		if _, ok := err.(stackTracer); ok {
-			return err
+			break
 		}
 
 		err = cause.Cause()
 	}
 
-	return nil
+	return err
 }

--- a/internal/logrus.go
+++ b/internal/logrus.go
@@ -27,6 +27,10 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
+type causer interface {
+	Cause() error
+}
+
 const (
 	stackTraceKey    = "stack_trace"
 	stackTraceFormat = "%s:%d"
@@ -94,7 +98,7 @@ func (logger logrusLogger) DebugWithFields(message string, fields map[string]int
 func (logger logrusLogger) getErrorLevelStackTrace(err error) []string {
 	var stackTrace []string
 	if stackTraceLevels[logrus.ErrorLevel] {
-		switch err := err.(type) {
+		switch err := firstStackTracerInErrorChain(err).(type) {
 		case stackTracer:
 			for _, frame := range err.StackTrace() {
 				stackTrace = append(stackTrace, fmt.Sprintf(stackTraceErrorPkgFormat, frame))
@@ -163,4 +167,21 @@ func shouldSkipFile(file string) bool {
 	}
 
 	return false
+}
+
+func firstStackTracerInErrorChain(err error) error {
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+
+		if _, ok := err.(stackTracer); ok {
+			return err
+		}
+
+		err = cause.Cause()
+	}
+
+	return nil
 }

--- a/internal/logrus_test.go
+++ b/internal/logrus_test.go
@@ -94,7 +94,7 @@ func TestFirstStackTracerInErrorChainWithOneError(t *testing.T) {
 
 	gotError := firstStackTracerInErrorChain(rootError)
 
-	assert.Equal(t, "root error", gotError.Error())
+	assert.EqualError(t, gotError, rootError.Error())
 }
 
 func TestFirstStackTracerInErrorChainWithMultipleErrors(t *testing.T) {
@@ -102,10 +102,10 @@ func TestFirstStackTracerInErrorChainWithMultipleErrors(t *testing.T) {
 	stackTracerError := errors.Wrap(rootError, "wrap root error")
 	newContextError := errors.WithMessage(stackTracerError, "new context added")
 
-	_, ok := newContextError.(stackTracer)
-	assert.False(t, ok)
-
 	gotError := firstStackTracerInErrorChain(newContextError)
 
-	assert.Equal(t, "wrap root error: root error", gotError.Error())
+	_, ok := gotError.(stackTracer)
+	assert.True(t, ok)
+
+	assert.EqualError(t, gotError, stackTracerError.Error())
 }

--- a/internal/logrus_test.go
+++ b/internal/logrus_test.go
@@ -86,7 +86,18 @@ func TestLogrusLoggerInvalidConfig(t *testing.T) {
 	NewLogrusLogger("invalid level", nil)
 }
 
-func TestFirstStackTracerInErrorChain(t *testing.T) {
+func TestFirstStackTracerInErrorChainWithOneError(t *testing.T) {
+	rootError := errors.New("root error")
+
+	_, ok := rootError.(stackTracer)
+	assert.True(t, ok)
+
+	gotError := firstStackTracerInErrorChain(rootError)
+
+	assert.Equal(t, "root error", gotError.Error())
+}
+
+func TestFirstStackTracerInErrorChainWithMultipleErrors(t *testing.T) {
 	rootError := errors.New("root error")
 	stackTracerError := errors.Wrap(rootError, "wrap root error")
 	newContextError := errors.WithMessage(stackTracerError, "new context added")

--- a/internal/logrus_test.go
+++ b/internal/logrus_test.go
@@ -3,9 +3,9 @@ package internal
 import (
 	"bytes"
 	"testing"
-	"errors"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/pkg/errors"
 )
 
 func TestLogrusLoggerLevel(t *testing.T) {
@@ -84,4 +84,17 @@ func TestLogrusLoggerInvalidConfig(t *testing.T) {
 	}()
 
 	NewLogrusLogger("invalid level", nil)
+}
+
+func TestFirstStackTracerInErrorChain(t *testing.T) {
+	rootError := errors.New("root error")
+	stackTracerError := errors.Wrap(rootError, "wrap root error")
+	newContextError := errors.WithMessage(stackTracerError, "new context added")
+
+	_, ok := newContextError.(stackTracer)
+	assert.False(t, ok)
+
+	gotError := firstStackTracerInErrorChain(newContextError)
+
+	assert.Equal(t, "wrap root error: root error", gotError.Error())
 }


### PR DESCRIPTION
***TL;DR***: ```errors.WithMessage(..)``` messing up with the stack trace

After playing a bit with ```pkg/errors``` and its methods, I realized that the stack trace of the error outputed was not the expected.

Imagine the following scenario:

```go
file x:
line 1 -> error1 := errors.New("error 1")

file y:
line 1 -> error2 := errors.Wrap(error1, "error 2")

file z:
line 1 -> error3 := errors.WithMessage(error2, "error 3")
line 2 -> Builder().Error(error3)
```

With the current implementation, if we pass the ```error3``` to our logger, since it doesn't implement the stackTracer interface, it falls into the default case, which calls the ```buildStackTrace()``` and prints the stack trace beginning in the function caller of error3 ```file z: line 2``` and this is not the expected.

The expected  behaviour is a stack trace beginning in ```file y: line 1```, because we are using the method ```Wrap``` that sets a stack trace point. If we change the ```Wrap``` to ```WithMessage``` the stack trace should begin in ```file x: line 1```.

This PR aims to solve this problem by using the ```first stackTracer error``` in the error chain if exists. If not, fallbacks to the default.

